### PR TITLE
Update setup() call with ARGUMENTS from scons

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -3,7 +3,7 @@ import glob
 from nbflow.scons import setup
 
 env = Environment(ENV=os.environ)
-setup(env, ["analyses"])
+setup(env, ["analyses"], ARGUMENTS)
 
 results = ["results/model_v_human.tex"]
 figures = ["figures/human_averages.pdf", "figures/model_v_human.pdf"]


### PR DESCRIPTION
Not sure if this example is deprecated in favor of the one in the nbflow repo, but jhamrick/nbflow#14 adds an argument to `setup`. 